### PR TITLE
Add readable article fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Column
 
-Minimal PWA to view archived news articles using archive.is.
+Minimal PWA to view archived news articles using archive.is with a readable fallback.
 
 ## Features
 
 - Validates news article URLs.
-- Generates archive.is links.
+- Generates archive.is links with automatic fallback to r.jina.ai for readable articles.
 - Simple, clean interface.
 - PWA installable.
 - Basic offline support.
@@ -14,7 +14,7 @@ Minimal PWA to view archived news articles using archive.is.
 
 1. Open Paper in browser.
 2. Paste URL.
-3. Click "View Archive".
+3. Click "View Archive". If archive.is is unavailable, a readable version will be loaded automatically.
 
 ## Installation
 

--- a/app.js
+++ b/app.js
@@ -20,6 +20,11 @@ const generateArchiveURL = (url) => {
     return `https://archive.is/latest/${encodeURIComponent(url)}`;
 };
 
+const generateReadableURL = (url) => {
+    // r.jina.ai provides a simplified view of the article
+    return `https://r.jina.ai/${url}`;
+};
+
 
 
 
@@ -107,6 +112,12 @@ function runTests() {
         'Archive URL should be correctly generated'
     );
 
+    const expectedReadableUrl = `https://r.jina.ai/${testUrl}`;
+    console.assert(
+        generateReadableURL(testUrl) === expectedReadableUrl,
+        'Readable URL should be correctly generated'
+    );
+
     console.log('All tests completed');
 }
 
@@ -138,6 +149,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
 
         errorMessage.textContent = '';
         const archiveURL = generateArchiveURL(url);
+        const readableURL = generateReadableURL(url);
         
         // Add a loading indicator
         errorMessage.textContent = 'Connecting to archive service...';
@@ -146,8 +158,8 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
             // Try to fetch the archive URL to check for rate limiting
             const controller = new AbortController();
             const timeoutId = setTimeout(() => controller.abort(), 5000); // 5 second timeout
-            
-            const response = await fetch(archiveURL, { 
+
+            const response = await fetch(archiveURL, {
                 method: 'HEAD',
                 signal: controller.signal,
                 mode: 'no-cors' // This is needed for cross-origin requests
@@ -160,17 +172,14 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
             window.location.href = archiveURL;
         } catch (err) {
             if (err.name === 'AbortError') {
-                errorMessage.textContent = 'Archive service is taking too long to respond. Redirecting anyway...';
-                setTimeout(() => {
-                    window.location.href = archiveURL;
-                }, 1000);
+                errorMessage.textContent = 'Archive service timed out. Loading readable version...';
             } else {
-                // For other errors, still try to redirect but with a warning
-                errorMessage.textContent = 'Archive service may be busy. Redirecting anyway...';
-                setTimeout(() => {
-                    window.location.href = archiveURL;
-                }, 1000);
+                errorMessage.textContent = 'Archive service unavailable. Loading readable version...';
             }
+
+            setTimeout(() => {
+                window.location.href = readableURL;
+            }, 1000);
         }
     });
 


### PR DESCRIPTION
## Summary
- add `generateReadableURL` to build fallback r.jina.ai links
- fall back to r.jina.ai if archive.is request fails
- test `generateReadableURL` in unit tests
- update README with the new feature

## Testing
- `node app.js`

------
https://chatgpt.com/codex/tasks/task_e_6852a5bd6074832e996d85a5e683300b